### PR TITLE
[Feature] - Added provider endpoint which returns information about the provider and its status if available.

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ import BilibiliUtilis from './bilibili';
 import CrunchyrollManager from './crunchyroll-token';
 import ImageProxy from './image-proxy';
 import M3U8Proxy from './m3u8-proxy';
+import Providers from './providers';
 
 const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   //await fastify.register(new RapidCloud().returnSID);
@@ -13,6 +14,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   await fastify.register(new BilibiliUtilis('en_US').returnVTT);
   await fastify.register(new ImageProxy().getImageProxy);
   await fastify.register(new M3U8Proxy().getM3U8Proxy);
+  await fastify.register(new Providers().getProviders);
 
   fastify.get('/', async (request: any, reply: any) => {
     reply.status(200).send('Welcome to Consumet Utils!');

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,0 +1,36 @@
+import { PROVIDERS_LIST } from '@consumet/extensions';
+import { FastifyRequest, FastifyReply, FastifyInstance, RegisterOptions } from 'fastify';
+
+type ProvidersRequest = FastifyRequest<{
+    Querystring: { type: keyof typeof PROVIDERS_LIST }
+}>
+
+export default class Providers {    
+    public getProviders = async (fastify: FastifyInstance, options: RegisterOptions) => {
+        fastify.get('/providers', {
+            preValidation: (request, reply, done)  => {
+                const { type } = request.query;
+
+                const providerTypes = Object.keys(PROVIDERS_LIST).map(element => element)
+
+                if (type === undefined) {
+                    reply.status(400)
+                    done(new Error('Type must not be empty. Available types: ' + providerTypes.toString()));
+                }
+
+                if (!providerTypes.includes(type)) {
+                    reply.status(400)
+                    done(new Error('Type must be either: ' + providerTypes.toString()));
+                }
+
+                done(undefined);
+            }
+        },
+        async (request: ProvidersRequest, reply: FastifyReply) => {
+            const { type } = request.query;
+            const providers = Object.values(PROVIDERS_LIST[type])
+                .sort((one, two) => one.name.localeCompare(two.name));
+            reply.status(200).send(providers.map(element => element.toString));
+        });
+    }
+}


### PR DESCRIPTION
What's up,

This pull request introduces a new endpoint under `/utils/providers` that returns all of the available provider that `Consumet.ts` offers. 

**How to use**
- `API_LINK/utils/providers?type=ANIME`
- `API_LINK/utils/providers?type=MANGA`
- Will work for all keys available for `PROVIDERS_LIST`.

This should offer a better solution to dynamically load various providers as the `Consumet.ts` library grows, without having to change the api much. I think one thing that we should add is a description for each provider in the future, and the available languages it could possibly return.

Hope you have a great time in Japan :)