### PR TITLE
Fix duplicate import compilation error, Updated README, and run lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ $ docker run -p 3000:3000 riimuru/consumet-api
 ```
 This will start the server on port 3000. You can access the server at http://localhost:3000/, And can change the port by changing the -p option to `-p <port>:3000`.
 
+Be sure to set `NODE_ENV` to `PROD` in your environment variables when running your own instance.
+Check out the `.env.example` file for more information.
+
 You can add `-d` flag to run the server in detached mode.
 
 ### Heroku

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,6 @@ import anime from './routes/anime';
 import manga from './routes/manga';
 import comics from './routes/comics';
 import lightnovels from './routes/light-novels';
-import fs from 'fs';
 import movies from './routes/movies';
 import meta from './routes/meta';
 import news from './routes/news';
@@ -105,20 +104,23 @@ export const tmdbApi = process.env.TMDB_KEY && process.env.TMDB_KEY;
     });
 
     // set interval to delete expired sessions every 1 hour
-    setInterval(() => {
-      const currentTime = new Date();
-      for (const [ip, session] of map.entries()) {
-        const { expiresIn } = session;
-        const sessionTime = new Date(expiresIn);
+    setInterval(
+      () => {
+        const currentTime = new Date();
+        for (const [ip, session] of map.entries()) {
+          const { expiresIn } = session;
+          const sessionTime = new Date(expiresIn);
 
-        // check if the session is expired
-        if (currentTime.getTime() > sessionTime.getTime()) {
-          console.log('session expired for', ip);
-          // if expired, delete the session and continue
-          map.delete(ip);
+          // check if the session is expired
+          if (currentTime.getTime() > sessionTime.getTime()) {
+            console.log('session expired for', ip);
+            // if expired, delete the session and continue
+            map.delete(ip);
+          }
         }
-      }
-    }, 1000 * 60 * 60);
+      },
+      1000 * 60 * 60,
+    );
   }
 
   console.log(chalk.green(`Starting server on port ${PORT}... 🚀`));
@@ -126,7 +128,7 @@ export const tmdbApi = process.env.TMDB_KEY && process.env.TMDB_KEY;
     console.warn(chalk.yellowBright('Redis not found. Cache disabled.'));
   if (!process.env.TMDB_KEY)
     console.warn(
-      chalk.yellowBright('TMDB api key not found. the TMDB meta route may not work.')
+      chalk.yellowBright('TMDB api key not found. the TMDB meta route may not work.'),
     );
 
   await fastify.register(books, { prefix: '/books' });
@@ -147,7 +149,7 @@ export const tmdbApi = process.env.TMDB_KEY && process.env.TMDB_KEY;
           process.env.NODE_ENV === 'DEMO'
             ? 'This is a demo of the api. You should only use this for testing purposes.'
             : ''
-        }`
+        }`,
       );
     });
     fastify.get('*', (request, reply) => {

--- a/src/routes/anime/9anime.ts
+++ b/src/routes/anime/9anime.ts
@@ -8,7 +8,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     {
       url: process.env.NINE_ANIME_PROXY as string,
     },
-    process.env?.NINE_ANIME_HELPER_KEY as string
+    process.env?.NINE_ANIME_HELPER_KEY as string,
   );
 
   fastify.get('/', (_, rp) => {
@@ -70,7 +70,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developer for help.' });
       }
-    }
+    },
   );
 
   fastify.get(
@@ -87,7 +87,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Please try again later.' });
       }
-    }
+    },
   );
 
   fastify.get('/helper', async (request: FastifyRequest, reply: FastifyReply) => {

--- a/src/routes/anime/animefox.ts
+++ b/src/routes/anime/animefox.ts
@@ -21,7 +21,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       const res = await animefox.fetchRecentEpisodes(page);
 
       reply.status(200).send(res);
-    }
+    },
   );
 
   fastify.get('/:query', async (request: FastifyRequest, reply: FastifyReply) => {

--- a/src/routes/anime/animepahe.ts
+++ b/src/routes/anime/animepahe.ts
@@ -54,7 +54,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developer for help.' });
       }
-    }
+    },
   );
 };
 

--- a/src/routes/anime/gogoanime.ts
+++ b/src/routes/anime/gogoanime.ts
@@ -83,7 +83,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Please try again later.' });
       }
-    }
+    },
   );
 
   fastify.get(
@@ -102,7 +102,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Please try again later.' });
       }
-    }
+    },
   );
 
   fastify.get('/top-airing', async (request: FastifyRequest, reply: FastifyReply) => {
@@ -134,7 +134,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developers for help.' });
       }
-    }
+    },
   );
 };
 

--- a/src/routes/anime/index.ts
+++ b/src/routes/anime/index.ts
@@ -33,7 +33,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     };
 
     queries.animeProvider = decodeURIComponent(
-      (request.params as { animeProvider: string; page: number }).animeProvider
+      (request.params as { animeProvider: string; page: number }).animeProvider,
     );
 
     queries.page = (request.query as { animeProvider: string; page: number }).page;
@@ -41,7 +41,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     if (queries.page! < 1) queries.page = 1;
 
     const provider = PROVIDERS_LIST.ANIME.find(
-      (provider: any) => provider.toString.name === queries.animeProvider
+      (provider: any) => provider.toString.name === queries.animeProvider,
     );
 
     try {

--- a/src/routes/anime/marin.ts
+++ b/src/routes/anime/marin.ts
@@ -18,7 +18,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     async (request: FastifyRequest, reply: FastifyReply) => {
       const page = (request.query as { page: number }).page;
       reply.status(200).send(await marin.recentEpisodes(page));
-    }
+    },
   );
 
   fastify.get('/:query', async (request: FastifyRequest, reply: FastifyReply) => {
@@ -71,7 +71,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developer for help.' });
       }
-    }
+    },
   );
 };
 

--- a/src/routes/anime/zoro.ts
+++ b/src/routes/anime/zoro.ts
@@ -32,7 +32,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       const res = await zoro.fetchRecentEpisodes(page);
 
       reply.status(200).send(res);
-    }
+    },
   );
 
   fastify.get('/info', async (request: FastifyRequest, reply: FastifyReply) => {

--- a/src/routes/light-novels/index.ts
+++ b/src/routes/light-novels/index.ts
@@ -20,7 +20,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
       queries.lightNovelProvider = decodeURIComponent(
         (request.params as { lightNovelProvider: string; page: number })
-          .lightNovelProvider
+          .lightNovelProvider,
       );
 
       queries.page = (request.query as { lightNovelProvider: string; page: number }).page;
@@ -28,7 +28,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       if (queries.page! < 1) queries.page = 1;
 
       const provider = PROVIDERS_LIST.LIGHT_NOVELS.find(
-        (provider: any) => provider.toString.name === queries.lightNovelProvider
+        (provider: any) => provider.toString.name === queries.lightNovelProvider,
       );
 
       try {
@@ -42,7 +42,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       } catch (err) {
         reply.status(500).send('Something went wrong. Please try again later.');
       }
-    }
+    },
   );
 };
 

--- a/src/routes/manga/index.ts
+++ b/src/routes/manga/index.ts
@@ -26,7 +26,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     };
 
     queries.mangaProvider = decodeURIComponent(
-      (request.params as { mangaProvider: string; page: number }).mangaProvider
+      (request.params as { mangaProvider: string; page: number }).mangaProvider,
     );
 
     queries.page = (request.query as { mangaProvider: string; page: number }).page;
@@ -34,7 +34,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     if (queries.page! < 1) queries.page = 1;
 
     const provider = PROVIDERS_LIST.MANGA.find(
-      (provider: any) => provider.toString.name === queries.mangaProvider
+      (provider: any) => provider.toString.name === queries.mangaProvider,
     );
 
     try {

--- a/src/routes/manga/mangadex.ts
+++ b/src/routes/manga/mangadex.ts
@@ -53,7 +53,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Please try again later.' });
       }
-    }
+    },
   );
 };
 

--- a/src/routes/meta/anilist-manga.ts
+++ b/src/routes/meta/anilist-manga.ts
@@ -29,7 +29,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
     if (typeof provider !== 'undefined') {
       const possibleProvider = PROVIDERS_LIST.MANGA.find(
-        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
       );
       anilist = new META.Anilist.Manga(possibleProvider);
     }
@@ -57,7 +57,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
     if (typeof provider !== 'undefined') {
       const possibleProvider = PROVIDERS_LIST.MANGA.find(
-        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
       );
       anilist = new META.Anilist.Manga(possibleProvider);
     }

--- a/src/routes/meta/anilist.ts
+++ b/src/routes/meta/anilist.ts
@@ -76,11 +76,11 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         id,
         year,
         status,
-        season
+        season,
       );
 
       reply.status(200).send(res);
-    }
+    },
   );
 
   fastify.get('/trending', async (request: FastifyRequest, reply: FastifyReply) => {
@@ -97,8 +97,8 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
               redis as Redis,
               `anilist:trending;${page};${perPage}`,
               async () => await anilist.fetchTrendingAnime(page, perPage),
-              60 * 60
-            )
+              60 * 60,
+            ),
           )
       : reply.status(200).send(await anilist.fetchTrendingAnime(page, perPage));
   });
@@ -117,8 +117,8 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
               redis as Redis,
               `anilist:popular;${page};${perPage}`,
               async () => await anilist.fetchPopularAnime(page, perPage),
-              60 * 60
-            )
+              60 * 60,
+            ),
           )
       : reply.status(200).send(await anilist.fetchPopularAnime(page, perPage));
   });
@@ -139,11 +139,11 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         perPage,
         weekStart,
         weekEnd,
-        notYetAired
+        notYetAired,
       );
 
       reply.status(200).send(res);
-    }
+    },
   );
 
   fastify.get('/genre', async (request: FastifyRequest, reply: FastifyReply) => {
@@ -178,7 +178,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       const res = await anilist.fetchRecentEpisodes(provider, page);
 
       reply.status(200).send(res);
-    }
+    },
   ),
     fastify.get('/random-anime', async (request: FastifyRequest, reply: FastifyReply) => {
       const anilist = generateAnilistMeta();
@@ -230,10 +230,10 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
                   anilist.fetchEpisodesListById(
                     id,
                     dub as boolean,
-                    fetchFiller as boolean
+                    fetchFiller as boolean,
                   ),
-                dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2
-              )
+                dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2,
+              ),
             )
         : reply
             .status(200)
@@ -281,13 +281,13 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
                 `anilist:info;${id};${isDub};${fetchFiller};${anilist.provider.name.toLowerCase()}`,
                 async () =>
                   anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean),
-                dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2
-              )
+                dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2,
+              ),
             )
         : reply
             .status(200)
             .send(
-              await anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean)
+              await anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean),
             );
     } catch (err: any) {
       reply.status(500).send({ message: err.message });
@@ -325,8 +325,8 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
                   redis,
                   `anilist:watch;${episodeId};${anilist.provider.name.toLowerCase()};${server}`,
                   async () => anilist.fetchEpisodeSources(episodeId, server),
-                  600
-                )
+                  600,
+                ),
               )
           : reply.status(200).send(await anilist.fetchEpisodeSources(episodeId, server));
 
@@ -338,14 +338,14 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developer for help.' });
       }
-    }
+    },
   );
 };
 
 const generateAnilistMeta = (provider: string | undefined = undefined): Anilist => {
   if (typeof provider !== 'undefined') {
     let possibleProvider = PROVIDERS_LIST.ANIME.find(
-      (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+      (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
     );
 
     if (possibleProvider instanceof NineAnime) {
@@ -354,7 +354,7 @@ const generateAnilistMeta = (provider: string | undefined = undefined): Anilist 
         {
           url: process.env?.NINE_ANIME_PROXY as string,
         },
-        process.env?.NINE_ANIME_HELPER_KEY as string
+        process.env?.NINE_ANIME_HELPER_KEY as string,
       );
     }
 

--- a/src/routes/meta/index.ts
+++ b/src/routes/meta/index.ts
@@ -22,7 +22,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     };
 
     queries.metaProvider = decodeURIComponent(
-      (request.params as { metaProvider: string; page: number }).metaProvider
+      (request.params as { metaProvider: string; page: number }).metaProvider,
     );
 
     queries.page = (request.query as { metaProvider: string; page: number }).page;
@@ -30,7 +30,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     if (queries.page! < 1) queries.page = 1;
 
     const provider = PROVIDERS_LIST.META.find(
-      (provider: any) => provider.toString.name === queries.metaProvider
+      (provider: any) => provider.toString.name === queries.metaProvider,
     );
 
     try {

--- a/src/routes/meta/mal.ts
+++ b/src/routes/meta/mal.ts
@@ -35,7 +35,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
     if (typeof provider !== 'undefined') {
       const possibleProvider = PROVIDERS_LIST.ANIME.find(
-        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
       );
 
       mal = new META.Myanimelist(possibleProvider);
@@ -65,7 +65,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
       if (typeof provider !== 'undefined') {
         const possibleProvider = PROVIDERS_LIST.ANIME.find(
-          (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+          (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
         );
 
         mal = new META.Myanimelist(possibleProvider);
@@ -82,7 +82,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developer for help.' });
       }
-    }
+    },
   );
 };
 

--- a/src/routes/meta/tmdb.ts
+++ b/src/routes/meta/tmdb.ts
@@ -31,7 +31,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
     if (typeof provider !== 'undefined') {
       const possibleProvider = PROVIDERS_LIST.MOVIES.find(
-        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+        (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
       );
       tmdb = new META.TMDB(tmdbApi, possibleProvider);
     }
@@ -50,7 +50,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       let tmdb = new META.TMDB(tmdbApi);
       if (typeof provider !== 'undefined') {
         const possibleProvider = PROVIDERS_LIST.MOVIES.find(
-          (p) => p.name.toLowerCase() === provider.toLocaleLowerCase()
+          (p) => p.name.toLowerCase() === provider.toLocaleLowerCase(),
         );
         tmdb = new META.TMDB(tmdbApi, possibleProvider);
       }
@@ -65,7 +65,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           .status(500)
           .send({ message: 'Something went wrong. Contact developer for help.' });
       }
-    }
+    },
   );
 };
 

--- a/src/routes/movies/flixhq.ts
+++ b/src/routes/movies/flixhq.ts
@@ -28,7 +28,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           redis as Redis,
           `flixhq:${query}:${page}`,
           async () => await flixhq.search(query, page ? page : 1),
-          60 * 60 * 6
+          60 * 60 * 6,
         )
       : await flixhq.search(query, page ? page : 1);
 
@@ -41,7 +41,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           redis as Redis,
           `flixhq:recent-shows`,
           async () => await flixhq.fetchRecentTvShows(),
-          60 * 60 * 3
+          60 * 60 * 3,
         )
       : await flixhq.fetchRecentTvShows();
 
@@ -54,7 +54,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           redis as Redis,
           `flixhq:recent-movies`,
           async () => await flixhq.fetchRecentMovies(),
-          60 * 60 * 3
+          60 * 60 * 3,
         )
       : await flixhq.fetchRecentMovies();
 
@@ -82,7 +82,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
               type === 'tv'
                 ? await flixhq.fetchTrendingTvShows()
                 : await flixhq.fetchTrendingMovies(),
-            60 * 60 * 3
+            60 * 60 * 3,
           )
         : type === 'tv'
         ? await flixhq.fetchTrendingTvShows()
@@ -111,7 +111,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
             redis as Redis,
             `flixhq:info:${id}`,
             async () => await flixhq.fetchMediaInfo(id),
-            60 * 60 * 3
+            60 * 60 * 3,
           )
         : await flixhq.fetchMediaInfo(id);
 
@@ -143,7 +143,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
             redis as Redis,
             `flixhq:watch:${episodeId}:${mediaId}:${server}`,
             async () => await flixhq.fetchEpisodeSources(episodeId, mediaId, server),
-            60 * 30
+            60 * 30,
           )
         : await flixhq.fetchEpisodeSources(episodeId, mediaId, server);
 
@@ -164,7 +164,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
             redis as Redis,
             `flixhq:servers:${episodeId}:${mediaId}`,
             async () => await flixhq.fetchEpisodeServers(episodeId, mediaId),
-            60 * 30
+            60 * 30,
           )
         : await flixhq.fetchEpisodeServers(episodeId, mediaId);
 

--- a/src/routes/movies/fmovies.ts
+++ b/src/routes/movies/fmovies.ts
@@ -12,7 +12,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     {
       url: process.env.NINE_ANIME_PROXY as string,
     },
-    process.env?.NINE_ANIME_HELPER_KEY
+    process.env?.NINE_ANIME_HELPER_KEY,
   );
 
   fastify.get('/', (_, rp) => {
@@ -34,7 +34,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
           redis as Redis,
           `fmovies:${query}:${page}`,
           async () => await fmovies.search(query, page ? page : 1),
-          60 * 60 * 6
+          60 * 60 * 6,
         )
       : await fmovies.search(query, page ? page : 1);
 
@@ -55,7 +55,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
             redis as Redis,
             `fmovies:info:${id}`,
             async () => await fmovies.fetchMediaInfo(id),
-            60 * 60 * 3
+            60 * 60 * 3,
           )
         : await fmovies.fetchMediaInfo(id);
 
@@ -87,7 +87,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
             redis as Redis,
             `fmovies:watch:${episodeId}:${mediaId}:${server}`,
             async () => await fmovies.fetchEpisodeSources(episodeId, mediaId, server),
-            60 * 30
+            60 * 30,
           )
         : await fmovies.fetchEpisodeSources(episodeId, mediaId, server);
 

--- a/src/routes/movies/index.ts
+++ b/src/routes/movies/index.ts
@@ -21,7 +21,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     };
 
     queries.movieProvider = decodeURIComponent(
-      (request.params as { movieProvider: string; page: number }).movieProvider
+      (request.params as { movieProvider: string; page: number }).movieProvider,
     );
 
     queries.page = (request.query as { movieProvider: string; page: number }).page;
@@ -29,7 +29,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     if (queries.page! < 1) queries.page = 1;
 
     const provider = PROVIDERS_LIST.MOVIES.find(
-      (provider: any) => provider.toString.name === queries.movieProvider
+      (provider: any) => provider.toString.name === queries.movieProvider,
     );
 
     try {

--- a/src/utils/bilibili.ts
+++ b/src/utils/bilibili.ts
@@ -23,7 +23,7 @@ class BilibiliUtilis {
           // );
           const ss = await axios.get(
             `https://kaguya.app/server/source?episode_id=${episodeId}&source_media_id=1&source_id=bilibili`,
-            { headers: { cookie: String(process.env.BILIBILI_COOKIE) } }
+            { headers: { cookie: String(process.env.BILIBILI_COOKIE) } },
           );
           //kaguya.app/server/source?episode_id=11560397&source_media_id=1&source_id=bilibili
           //console.log(ss.data);
@@ -40,7 +40,7 @@ class BilibiliUtilis {
             .status(500)
             .send({ message: 'Something went wrong. Contact developer for help.' });
         }
-      }
+      },
     );
   };
 
@@ -62,7 +62,7 @@ class BilibiliUtilis {
             .status(500)
             .send({ message: 'Something went wrong. Contact developer for help.' });
         }
-      }
+      },
     );
   };
 }

--- a/src/utils/image-proxy.ts
+++ b/src/utils/image-proxy.ts
@@ -5,7 +5,7 @@ class ImageProxy {
   public async getImageProxy(fastify: FastifyInstance, options: RegisterOptions) {
     const getImage = async (
       url: string,
-      options: AxiosRequestConfig
+      options: AxiosRequestConfig,
     ): Promise<string> => {
       const data = await axios
         .get(url, {
@@ -34,7 +34,7 @@ class ImageProxy {
       reply.header('Access-Control-Allow-Methods', 'GET');
       reply.header(
         'Access-Control-Allow-Headers',
-        'Origin, X-Requested-With, Content-Type, Accept'
+        'Origin, X-Requested-With, Content-Type, Accept',
       );
       reply.header('Access-Control-Allow-Credentials', 'true');
       reply.send(await getImage(url, { headers: JSON.parse(headers) }));

--- a/src/utils/m3u8-proxy.ts
+++ b/src/utils/m3u8-proxy.ts
@@ -43,13 +43,13 @@ class M3U8Proxy {
               'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 Edg/107.0.1418.35',
             watchsb: 'streamsb',
           },
-        }
+        },
       );
 
       //const decodedData = Buffer.from(data, 'binary').toString('utf8');
       reply.header(
         'Content-Type',
-        decodedUrl.startsWith('https') ? 'application/vnd.apple.mpegurl' : 'video/mp2t'
+        decodedUrl.startsWith('https') ? 'application/vnd.apple.mpegurl' : 'video/mp2t',
       );
       reply.header('Access-Control-Allow-Origin', '*');
       reply.header('Access-Control-Allow-Headers', '*');

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -19,8 +19,8 @@ export default class Providers {
             reply.status(400);
             done(
               new Error(
-                'Type must not be empty. Available types: ' + providerTypes.toString()
-              )
+                'Type must not be empty. Available types: ' + providerTypes.toString(),
+              ),
             );
           }
 
@@ -35,10 +35,10 @@ export default class Providers {
       async (request: ProvidersRequest, reply: FastifyReply) => {
         const { type } = request.query;
         const providers = Object.values(PROVIDERS_LIST[type]).sort((one, two) =>
-          one.name.localeCompare(two.name)
+          one.name.localeCompare(two.name),
         );
         reply.status(200).send(providers.map((element) => element.toString));
-      }
+      },
     );
   };
 }


### PR DESCRIPTION
There was a ts compilation error where there was a duplicate `fs` import in main.ts which prevented the app from running.

I also updated the README to mention changing the `NODE_ENV` environment variable to `PROD` if you were self-hosting the api.

Then, I just ran the linter.

Fixes https://github.com/consumet/api.consumet.org/issues/509