### PR TITLE
fix: Vercel 500 crash error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,14 +23,14 @@ export const redis =
     password: process.env.REDIS_PASSWORD,
   });
 
+const fastify = Fastify({
+  maxParamLength: 1000,
+  logger: true,
+});
 export const tmdbApi = process.env.TMDB_KEY && process.env.TMDB_KEY;
 (async () => {
   const PORT = Number(process.env.PORT) || 3000;
 
-  const fastify = Fastify({
-    maxParamLength: 1000,
-    logger: true,
-  });
   await fastify.register(FastifyCors, {
     origin: '*',
     methods: 'GET',
@@ -145,10 +145,9 @@ export const tmdbApi = process.env.TMDB_KEY && process.env.TMDB_KEY;
   try {
     fastify.get('/', (_, rp) => {
       rp.status(200).send(
-        `Welcome to consumet api! 🎉 \n${
-          process.env.NODE_ENV === 'DEMO'
-            ? 'This is a demo of the api. You should only use this for testing purposes.'
-            : ''
+        `Welcome to consumet api! 🎉 \n${process.env.NODE_ENV === 'DEMO'
+          ? 'This is a demo of the api. You should only use this for testing purposes.'
+          : ''
         }`,
       );
     });
@@ -168,3 +167,7 @@ export const tmdbApi = process.env.TMDB_KEY && process.env.TMDB_KEY;
     process.exit(1);
   }
 })();
+export default async function handler(req: any, res: any) {
+  await fastify.ready()
+  fastify.server.emit('request', req, res)
+}


### PR DESCRIPTION
Fixes the following error on vercel:
Invalid export found in module "/var/task/src/main.js".
The default export must be a function or server.
INIT_REPORT Init Duration: 868.45 ms    Phase: init    Status: error    Error Type: Runtime.ExitError
Invalid export found in module "/var/task/src/main.js".
The default export must be a function or server.
INIT_REPORT Init Duration: 1501.21 ms    Phase: invoke    Status: error    Error Type: Runtime.ExitError
Error: Runtime exited with error: exit status 1
Runtime.ExitError

This occurred probably due to vercel updating their node environments because it worked fine after some adjustment in code.