### PR TITLE
fix: cannot fetch gogoanime info when do not use redis

### DIFF
--- a/src/routes/anime/gogoanime.ts
+++ b/src/routes/anime/gogoanime.ts
@@ -56,7 +56,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         .fetchAnimeInfo(id)
         .catch((err) => reply.status(404).send({ message: err })),
         redisCacheTime,
-      ) : gogoanime
+      ) : await gogoanime
       .fetchAnimeInfo(id)
       .catch((err) => reply.status(404).send({ message: err }));
 


### PR DESCRIPTION
When I do not provide Redis host and Redis port in .env file, meaning running the API without redis, I cannot fetch the gogoanime info API, it return `{}`. But when I turn on the Redis, it works. 

Adding `await` can solve this problem