### PR TITLE
chore: Update code to be more consisent in docs

### DIFF
--- a/src/routes/anime/zoro.ts
+++ b/src/routes/anime/zoro.ts
@@ -4,12 +4,16 @@ import { StreamingServers } from '@consumet/extensions/dist/models';
 
 const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   const zoro = new ANIME.Zoro(process.env.ZORO_URL);
+  let baseUrl = "https://hianime.to";
+  if(process.env.ZORO_URL){
+    baseUrl = `https://${process.env.ZORO_URL}`;
+  }
 
   fastify.get('/', (_, rp) => {
     rp.status(200).send({
       intro:
-        "Welcome to the zoro provider: check out the provider's website @ https://zoro.to/",
-      routes: ['/:query', '/info/:id', '/watch/:episodeId'],
+        `Welcome to the zoro provider: check out the provider's website @ ${baseUrl}`,
+      routes: ['/:query', '/recent-episodes', '/top-airing', '/most-popular', '/most-favorite', '/latest-completed', '/recent-added', '/info?id', '/watch/:episodeId'],
       documentation: 'https://docs.consumet.org/#tag/zoro',
     });
   });
@@ -136,9 +140,11 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         .send({ message: 'Something went wrong. Contact developer for help.' });
     }
   });
-
-  fastify.get('/watch', async (request: FastifyRequest, reply: FastifyReply) => {
-    const episodeId = (request.query as { episodeId: string }).episodeId;
+  const watch = async (request: FastifyRequest, reply: FastifyReply) => {
+    let episodeId = (request.params as { episodeId: string }).episodeId;
+    if(!episodeId){
+      episodeId = (request.query as { episodeId: string }).episodeId;
+    }
 
     const server = (request.query as { server: string }).server as StreamingServers;
 
@@ -159,7 +165,9 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         .status(500)
         .send({ message: 'Something went wrong. Contact developer for help.' });
     }
-  });
+  };
+  fastify.get('/watch', watch);
+  fastify.get('/watch/:episodeId', watch);
 };
 
 export default routes;


### PR DESCRIPTION
Someone complained to me that they cannot fetch episode sources using zoro endpoint. Upon looking at the code I saw why he is having the error. Documentation and code have mismatched. 

Let us assume that episodeId = the-irregular-at-magic-high-school-season-3-19142$episode$123216$both

It is supposed to be requested like this at the current version according to api code:
http://yourapiurl/anime/zoro/watch?episodeId=the-irregular-at-magic-high-school-season-3-19142$episode$123216$both

But according to docs it is supposed to be requested like this:
http://yourapiurl/anime/zoro/watch/the-irregular-at-magic-high-school-season-3-19142$episode$123216$both

This is the link to the said documentation:
https://docs.consumet.org/rest-api/Anime/zoro/get-anime-episode-streaming-links

Made a pr to accommodate both changes, and also add more visible routes on /anime/zoro index endpoint