### PR TITLE
fix(manga | movies): Add missing mangaId in fetchChapterPages, new sflix provider and changes in /servers endpoint error logging in movies routes, add server params in dramacool's episode fetching

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ "14.x" ]
+        node-version: [ "18.x" ]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,4 +24,4 @@ jobs:
       - name: Install dependencies & build
         run: |
           npm install
-          tsc
+          npx tsc

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "homepage": "https://github.com/consumet/consumet.ts#readme",
     "dependencies": {
         "@consumet/extensions": "github:consumet/consumet.ts",
-        "@fastify/cors": "^8.2.0",
-        "@types/fastify-cors": "^2.1.0",
+        "@fastify/cors": "^8.5.0",
         "@types/node": "^18.11.17",
         "@types/ws": "^8.5.3",
         "axios": "^1.0.0",
@@ -33,7 +32,6 @@
         "cheerio": "1.0.0-rc.12",
         "dotenv": "^16.0.3",
         "fastify": "^4.10.2",
-        "fastify-cors": "^6.1.0",
         "ioredis": "^5.2.4",
         "reconnecting-websocket": "^4.4.0",
         "ts-node": "^10.9.1",
@@ -42,6 +40,7 @@
     },
     "devDependencies": {
         "nodemon": "3.0.1",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "typescript": "5.3.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "ioredis": "^5.2.4",
         "reconnecting-websocket": "^4.4.0",
         "ts-node": "^10.9.1",
-        "typescript": "5.3.3",
         "ws": "^8.8.1"
     },
     "devDependencies": {

--- a/src/routes/manga/mangakakalot.ts
+++ b/src/routes/manga/mangakakalot.ts
@@ -41,13 +41,17 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
   fastify.get('/read', async (request: FastifyRequest, reply: FastifyReply) => {
     const chapterId = (request.query as { chapterId: string }).chapterId;
+    const mangaId = (request.query as { mangaId: string }).mangaId;
 
     if (typeof chapterId === 'undefined')
       return reply.status(400).send({ message: 'chapterId is required' });
 
+    if (typeof mangaId === 'undefined')
+      return reply.status(400).send({ message: 'mangaId is required' });
+
     try {
       const res = await mangakakalot
-        .fetchChapterPages(chapterId)
+        .fetchChapterPages(chapterId,mangaId)
         .catch((err: Error) => reply.status(404).send({ message: err.message }));
 
       reply.status(200).send(res);

--- a/src/routes/movies/dramacool.ts
+++ b/src/routes/movies/dramacool.ts
@@ -56,13 +56,13 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   fastify.get('/watch', async (request: FastifyRequest, reply: FastifyReply) => {
     const episodeId = (request.query as { episodeId: string }).episodeId;
     // const mediaId = (request.query as { mediaId: string }).mediaId;
-    // const server = (request.query as { server: StreamingServers }).server;
+    const server = (request.query as { server: StreamingServers }).server;
 
     if (typeof episodeId === 'undefined')
       return reply.status(400).send({ message: 'episodeId is required' });
     try {
       const res = await dramacool
-        .fetchEpisodeSources(episodeId)
+        .fetchEpisodeSources(episodeId,server)
         .catch((err) => reply.status(404).send({ message: 'Media Not found.' }));
 
       reply.status(200).send(res);

--- a/src/routes/movies/goku.ts
+++ b/src/routes/movies/goku.ts
@@ -180,6 +180,12 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         async (request: FastifyRequest, reply: FastifyReply) => {
             const episodeId = (request.query as { episodeId: string }).episodeId;
             const mediaId = (request.query as { mediaId: string }).mediaId;
+
+            if (typeof episodeId === "undefined")
+                return reply.status(400).send({ message: "episodeId is required" });
+            if (typeof mediaId === "undefined")
+                return reply.status(400).send({ message: "mediaId is required" });
+            
             try {
                 let res = redis
                     ? await cache.fetch(

--- a/src/routes/movies/index.ts
+++ b/src/routes/movies/index.ts
@@ -7,6 +7,7 @@ import dramacool from './dramacool';
 import fmovies from './fmovies';
 import goku from './goku';
 import movieshd from './movieshd';
+import sflix from './sflix';
 const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   await fastify.register(flixhq, { prefix: '/flixhq' });
   await fastify.register(viewasian, { prefix: '/viewasian' });
@@ -14,6 +15,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   await fastify.register(fmovies, { prefix: '/fmovies' });
   await fastify.register(goku, { prefix: '/goku' });
   await fastify.register(movieshd, { prefix: '/movieshd' });
+  await fastify.register(sflix, { prefix: '/sflix' });
   fastify.get('/', async (request: any, reply: any) => {
     reply.status(200).send('Welcome to Consumet Movies and TV Shows');
   });

--- a/src/routes/movies/movieshd.ts
+++ b/src/routes/movies/movieshd.ts
@@ -180,6 +180,12 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         async (request: FastifyRequest, reply: FastifyReply) => {
             const episodeId = (request.query as { episodeId: string }).episodeId;
             const mediaId = (request.query as { mediaId: string }).mediaId;
+
+            if (typeof episodeId === "undefined")
+                return reply.status(400).send({ message: "episodeId is required" });
+            if (typeof mediaId === "undefined")
+                return reply.status(400).send({ message: "mediaId is required" });
+            
             try {
                 let res = redis
                     ? await cache.fetch(


### PR DESCRIPTION
#### Changes
- **Manga**: Fixed missing `mangaId` in `fetchChapterPages`.
- **Movies**: Added new `sflix` provider and improved `/servers` endpoint error logging.
- **Dramacool**: Added server params to episode fetching route.

#### Related Issue  
References #637.