### PR TITLE
fix+feat(anix.sh): Added type variable to recent-episodes, watch and servers to fetch SUB, DUB, RAW; added some error handling

### DIFF
--- a/src/routes/anime/anix.ts
+++ b/src/routes/anime/anix.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest, FastifyReply, FastifyInstance, RegisterOptions } from 'fastify';
 import { ANIME } from '@consumet/extensions';
+import { StreamingServers } from '@consumet/extensions/dist/models';
 
 const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   const anix = new ANIME.Anix();
@@ -8,7 +9,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     rp.status(200).send({
       intro:
         "Welcome to the Anix provider: check out the provider's website @ https://anix.sh",
-      routes: ['/:query', '/recent-episodes', '/info/:id', '/watch/:id/:episodeId', '/servers/:id/:episodeId'],
+      routes: ['/:query', '/recent-episodes', '/info/:id', '/watch/:id/:episodeId', '/servers/:id/:episodeId', '/servers-type/:id/:episodeId'],
       documentation: 'https://docs.consumet.org/#tag/anix',
     });
   });
@@ -26,10 +27,16 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     '/recent-episodes',
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { page = 1 } = request.query as { page?: number };
-  
+      const type = (request.query as { type?: number }).type;
+
       try {
-        const res = await anix.fetchRecentEpisodes(page);
-  
+        let res;
+        if (typeof type === 'undefined') {
+          res = await anix.fetchRecentEpisodes(page);
+        } else {
+          res = await anix.fetchRecentEpisodes(page, type);
+        }
+      
         reply.status(200).send(res);
       } catch (err) {
         console.error(err);
@@ -60,11 +67,20 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     '/watch/:id/:episodeId',
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id, episodeId } = request.params as { id: string; episodeId: string };
-      const { server } = request.query as { server?: string };
+      const server = (request.query as { server: string }).server as StreamingServers;
+      const type = (request.query as { type: string }).type ?? 'sub';
   
+      if (typeof id === 'undefined')
+        return reply.status(400).send({ message: 'id is required' });
+  
+      if (typeof episodeId === 'undefined')
+        return reply.status(400).send({ message: 'episodeId is required' });
+
       try {
-        const res = await anix.fetchEpisodeSources(id, episodeId, server);
-  
+        const res = await anix
+          .fetchEpisodeSources(id, episodeId, server, type)
+          .catch((err) => reply.status(404).send({ message: err }));
+
         reply.status(200).send(res);
       } catch (err) {
         console.error(err);
@@ -80,9 +96,17 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id, episodeId } = request.params as { id: string; episodeId: string };
   
-      try {
-        const res = await anix.fetchEpisodeServers(id, episodeId);
+      if (typeof id === 'undefined')
+        return reply.status(400).send({ message: 'id is required' });
   
+      if (typeof episodeId === 'undefined')
+        return reply.status(400).send({ message: 'episodeId is required' });
+
+      try {
+        const res = await anix
+          .fetchEpisodeServers(id, episodeId)
+          .catch((err) => reply.status(404).send({ message: err }));
+
         reply.status(200).send(res);
       } catch (err) {
         console.error(err);
@@ -92,6 +116,31 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       }
     },
   );
+
+  fastify.get(
+    '/servers-type/:id/:episodeId',
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id, episodeId } = request.params as { id: string; episodeId: string };
+      const type = (request.query as { type: string }).type ?? 'sub';
+
+      if (typeof id === 'undefined')
+        return reply.status(400).send({ message: 'id is required' });
+
+      if (typeof episodeId === 'undefined')
+        return reply.status(400).send({ message: 'episodeId is required' });
+
+      try {
+        const res = await anix
+          .fetchEpisodeServerType(id, episodeId, type)
+          .catch((err) => reply.status(404).send({ message: err }));
+
+        reply.status(200).send(res);
+      } catch (err) {
+        reply
+          .status(500)
+          .send({ message: 'Something went wrong. Contact developer for help.' });
+      }
+  });
 };
 
 export default routes;

--- a/src/routes/anime/anix.ts
+++ b/src/routes/anime/anix.ts
@@ -9,7 +9,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     rp.status(200).send({
       intro:
         "Welcome to the Anix provider: check out the provider's website @ https://anix.sh",
-      routes: ['/:query', '/recent-episodes', '/info/:id', '/watch/:id/:episodeId', '/servers/:id/:episodeId', '/servers-type/:id/:episodeId'],
+      routes: ['/:query', '/recent-episodes', '/info/:id', '/watch/:id/:episodeId', '/servers/:id/:episodeId'],
       documentation: 'https://docs.consumet.org/#tag/anix',
     });
   });
@@ -95,6 +95,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     '/servers/:id/:episodeId',
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id, episodeId } = request.params as { id: string; episodeId: string };
+      const type = (request.query as { type?: string }).type;
   
       if (typeof id === 'undefined')
         return reply.status(400).send({ message: 'id is required' });
@@ -103,9 +104,16 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         return reply.status(400).send({ message: 'episodeId is required' });
 
       try {
-        const res = await anix
-          .fetchEpisodeServers(id, episodeId)
-          .catch((err) => reply.status(404).send({ message: err }));
+        let res;
+        if (typeof type === 'undefined') {
+          res = await anix
+            .fetchEpisodeServers(id, episodeId)
+            .catch((err) => reply.status(404).send({ message: err }));;
+        } else {
+          res = await anix
+            .fetchEpisodeServerType(id, episodeId, type)
+            .catch((err) => reply.status(404).send({ message: err }));;
+        }
 
         reply.status(200).send(res);
       } catch (err) {
@@ -116,31 +124,6 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       }
     },
   );
-
-  fastify.get(
-    '/servers-type/:id/:episodeId',
-    async (request: FastifyRequest, reply: FastifyReply) => {
-      const { id, episodeId } = request.params as { id: string; episodeId: string };
-      const type = (request.query as { type: string }).type ?? 'sub';
-
-      if (typeof id === 'undefined')
-        return reply.status(400).send({ message: 'id is required' });
-
-      if (typeof episodeId === 'undefined')
-        return reply.status(400).send({ message: 'episodeId is required' });
-
-      try {
-        const res = await anix
-          .fetchEpisodeServerType(id, episodeId, type)
-          .catch((err) => reply.status(404).send({ message: err }));
-
-        reply.status(200).send(res);
-      } catch (err) {
-        reply
-          .status(500)
-          .send({ message: 'Something went wrong. Contact developer for help.' });
-      }
-  });
 };
 
 export default routes;


### PR DESCRIPTION
- Added type variable to endpoints /recent-episodes, /watch & /servers to be able to fetch different types like SUB, DUB, RAW appropriately.
- Added some 404 error handling to these endpoints.
- Added error handling for empty anime id and episode id.
- Changed variable server to use StreamingServers from @consumet/extensions/dist/models instead of just a string.

Sorry for the double-PR, I completely missed those and thanks to @carlosesteven for [pointing it out and providing some of the code for this PR](https://github.com/consumet/api.consumet.org/pull/650#issuecomment-2586395629). 