### PR TITLE
fix(meta/anilist): Change the default provider to Zoro from Gogo

### DIFF
--- a/src/routes/anime/animekai.ts
+++ b/src/routes/anime/animekai.ts
@@ -17,6 +17,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
         '/latest-completed',
         '/new-releases',
         '/recent-added',
+        '/recent-episodes',
         '/schedule/:date',
         '/spotlight',
         '/search-suggestions/:query',
@@ -75,6 +76,18 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     const page = (request.query as { page: number }).page;
     try {
       const res = await animekai.fetchRecentlyAdded(page);
+      reply.status(200).send(res);
+    } catch (error) {
+      reply.status(500).send({
+        message: 'Something went wrong. Contact developer for help.',
+      });
+    }
+  });
+
+  fastify.get('/recent-episodes', async (request: FastifyRequest, reply: FastifyReply) => {
+    const page = (request.query as { page: number }).page;
+    try {
+      const res = await animekai.fetchRecentlyUpdated(page);
       reply.status(200).send(res);
     } catch (error) {
       reply.status(500).send({

--- a/src/routes/meta/anilist.ts
+++ b/src/routes/meta/anilist.ts
@@ -8,7 +8,7 @@ import { StreamingServers } from '@consumet/extensions/dist/models';
 import cache from '../../utils/cache';
 import { redis } from '../../main';
 import NineAnime from '@consumet/extensions/dist/providers/anime/9anime';
-import Gogoanime from '@consumet/extensions/dist/providers/anime/gogoanime';
+import Zoro from '@consumet/extensions/dist/providers/anime/zoro';
 
 const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   fastify.get('/', (_, rp) => {
@@ -92,15 +92,15 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
     redis
       ? reply
-          .status(200)
-          .send(
-            await cache.fetch(
-              redis as Redis,
-              `anilist:trending;${page};${perPage}`,
-              async () => await anilist.fetchTrendingAnime(page, perPage),
-              60 * 60,
-            ),
-          )
+        .status(200)
+        .send(
+          await cache.fetch(
+            redis as Redis,
+            `anilist:trending;${page};${perPage}`,
+            async () => await anilist.fetchTrendingAnime(page, perPage),
+            60 * 60,
+          ),
+        )
       : reply.status(200).send(await anilist.fetchTrendingAnime(page, perPage));
   });
 
@@ -112,15 +112,15 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
 
     redis
       ? reply
-          .status(200)
-          .send(
-            await cache.fetch(
-              redis as Redis,
-              `anilist:popular;${page};${perPage}`,
-              async () => await anilist.fetchPopularAnime(page, perPage),
-              60 * 60,
-            ),
-          )
+        .status(200)
+        .send(
+          await cache.fetch(
+            redis as Redis,
+            `anilist:popular;${page};${perPage}`,
+            async () => await anilist.fetchPopularAnime(page, perPage),
+            60 * 60,
+          ),
+        )
       : reply.status(200).send(await anilist.fetchPopularAnime(page, perPage));
   });
 
@@ -172,7 +172,7 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
   fastify.get(
     '/recent-episodes',
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const provider = (request.query as { provider: 'gogoanime' | 'zoro' }).provider;
+      const provider = (request.query as { provider: 'zoro' }).provider;
       const page = (request.query as { page: number }).page;
       const perPage = (request.query as { perPage: number }).perPage;
 
@@ -224,23 +224,23 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     try {
       redis
         ? reply
-            .status(200)
-            .send(
-              await cache.fetch(
-                redis,
-                `anilist:episodes;${id};${dub};${fetchFiller};${anilist.provider.name.toLowerCase()}`,
-                async () =>
-                  anilist.fetchEpisodesListById(
-                    id,
-                    dub as boolean,
-                    fetchFiller as boolean,
-                  ),
-                dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2,
-              ),
-            )
+          .status(200)
+          .send(
+            await cache.fetch(
+              redis,
+              `anilist:episodes;${id};${dub};${fetchFiller};${anilist.provider.name.toLowerCase()}`,
+              async () =>
+                anilist.fetchEpisodesListById(
+                  id,
+                  dub as boolean,
+                  fetchFiller as boolean,
+                ),
+              dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2,
+            ),
+          )
         : reply
-            .status(200)
-            .send(await anilist.fetchEpisodesListById(id, dub, fetchFiller as boolean));
+          .status(200)
+          .send(await anilist.fetchEpisodesListById(id, dub, fetchFiller as boolean));
     } catch (err) {
       return reply.status(404).send({ message: 'Anime not found' });
     }
@@ -277,21 +277,21 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     try {
       redis
         ? reply
-            .status(200)
-            .send(
-              await cache.fetch(
-                redis,
-                `anilist:info;${id};${isDub};${fetchFiller};${anilist.provider.name.toLowerCase()}`,
-                async () =>
-                  anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean),
-                dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2,
-              ),
-            )
+          .status(200)
+          .send(
+            await cache.fetch(
+              redis,
+              `anilist:info;${id};${isDub};${fetchFiller};${anilist.provider.name.toLowerCase()}`,
+              async () =>
+                anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean),
+              dayOfWeek === 0 || dayOfWeek === 6 ? 60 * 120 : (60 * 60) / 2,
+            ),
+          )
         : reply
-            .status(200)
-            .send(
-              await anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean),
-            );
+          .status(200)
+          .send(
+            await anilist.fetchAnimeInfo(id, isDub as boolean, fetchFiller as boolean),
+          );
     } catch (err: any) {
       reply.status(500).send({ message: err.message });
     }
@@ -326,33 +326,33 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
       try {
         redis
           ? reply
-              .status(200)
-              .send(
-                await cache.fetch(
-                  redis,
-                  `anilist:watch;${episodeId};${anilist.provider.name.toLowerCase()};${server};${isDub ? 'dub' : 'sub'}`,
-                  async () =>
-                    provider === 'zoro' || provider === 'animekai'
-                      ? await anilist.fetchEpisodeSources(
-                          episodeId,
-                          server,
-                          isDub ? SubOrSub.DUB : SubOrSub.SUB,
-                        )
-                      : await anilist.fetchEpisodeSources(episodeId, server),
-                  600,
-                ),
-              )
-          : reply
-              .status(200)
-              .send(
-                provider === 'zoro' || provider === 'animekai'
-                  ? await anilist.fetchEpisodeSources(
+            .status(200)
+            .send(
+              await cache.fetch(
+                redis,
+                `anilist:watch;${episodeId};${anilist.provider.name.toLowerCase()};${server};${isDub ? 'dub' : 'sub'}`,
+                async () =>
+                  provider === 'zoro' || provider === 'animekai'
+                    ? await anilist.fetchEpisodeSources(
                       episodeId,
                       server,
                       isDub ? SubOrSub.DUB : SubOrSub.SUB,
                     )
-                  : await anilist.fetchEpisodeSources(episodeId, server),
-              );
+                    : await anilist.fetchEpisodeSources(episodeId, server),
+                600,
+              ),
+            )
+          : reply
+            .status(200)
+            .send(
+              provider === 'zoro' || provider === 'animekai'
+                ? await anilist.fetchEpisodeSources(
+                  episodeId,
+                  server,
+                  isDub ? SubOrSub.DUB : SubOrSub.SUB,
+                )
+                : await anilist.fetchEpisodeSources(episodeId, server),
+            );
 
         anilist = new META.Anilist(undefined, {
           url: process.env.PROXY as string | string[],
@@ -374,15 +374,15 @@ const routes = async (fastify: FastifyInstance, options: RegisterOptions) => {
     try {
       redis
         ? reply
-            .status(200)
-            .send(
-              await cache.fetch(
-                redis,
-                `anilist:staff;${id}`,
-                async () => await anilist.fetchStaffById(Number(id)),
-                60 * 60,
-              ),
-            )
+          .status(200)
+          .send(
+            await cache.fetch(
+              redis,
+              `anilist:staff;${id}`,
+              async () => await anilist.fetchStaffById(Number(id)),
+              60 * 60,
+            ),
+          )
         : reply.status(200).send(await anilist.fetchStaffById(Number(id)));
     } catch (err: any) {
       reply.status(404).send({ message: err.message });
@@ -410,8 +410,8 @@ const generateAnilistMeta = (provider: string | undefined = undefined): Anilist 
       url: process.env.PROXY as string | string[],
     });
   } else {
-    // default provider is gogoanime
-    return new Anilist(new Gogoanime(), {
+    // default provider is Zoro
+    return new Anilist(new Zoro(), {
       url: process.env.PROXY as string | string[],
     });
   }


### PR DESCRIPTION
Since Gogo is dead, it might be a good idea to change meta/anilist to default to Zoro.

Closes #672 
Closes #660 
Closes #659 